### PR TITLE
Update File System Health Check to read/write into temp directory

### DIFF
--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -135,10 +135,11 @@ class HealthChecker {
     try {
       const fs = await import('fs/promises')
       const path = await import('path')
+      const os = await import('os')
       
       // Check if we can read/write to the data directory
-      const dataDir = path.join(process.cwd(), 'data')
-      const testFile = path.join(dataDir, '.health-check')
+      const tempDir = os.tmpdir()
+      const testFile = path.join(tempDir, '.health-check')
       
       // Try to write a test file
       await fs.writeFile(testFile, JSON.stringify({ timestamp: new Date() }))


### PR DESCRIPTION
The file system health check now performs reads and writes into ```temp``` directory, which is not ```read-only``` on serverless deployment. This will correctly determines ```File System Health```.

- I have tested it on both ```local``` and ```deployed``` instance of the website.

<img width="2825" height="1443" alt="image" src="https://github.com/user-attachments/assets/34ec71af-74bc-405a-be22-0c5bcf4143c8" />
