### PR TITLE
Migrate Maintenance state to supabase and add Redirection

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+// Force dynamic rendering for all admin routes to avoid build-time errors 
+// when calling getServerSession() or other header-dependent functions.
+export const dynamic = 'force-dynamic'
+
+export default function AdminRootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="admin-layout">
+      {children}
+    </div>
+  )
+}

--- a/app/maintenance/page.tsx
+++ b/app/maintenance/page.tsx
@@ -1,14 +1,18 @@
 import React from "react"
-import { Construction, Terminal, AlertTriangle, ExternalLink } from "lucide-react"
+import { Terminal, AlertTriangle, ExternalLink } from "lucide-react"
+import { getMaintenanceConfig } from "@/lib/maintenance"
 
-export default function MaintenancePage() {
+export const dynamic = "force-dynamic"
+
+export default async function MaintenancePage() {
+  const config = await getMaintenanceConfig()
   const charGif = "https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHBvM3p1eG1zZGthNGs5bHkwa3l4Mjc4ZGVzN2RveTNwamw5eHZ1dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qIMZVXWJHQI0Qu3Pe9/giphy.gif"
 
   return (
     <div className="min-h-screen bg-[#E3E3E3] font-mono flex flex-col items-center justify-center p-0 relative overflow-hidden">
       {/* Background Grid Pattern - Very Roblox Studio */}
       <div className="absolute inset-0 opacity-[0.05] pointer-events-none" 
-           style={{ backgroundImage: `linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)`, size: '20px 20px', backgroundSize: '40px 40px' }} 
+           style={{ backgroundImage: `linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)`, backgroundSize: '40px 40px' }} 
       />
 
       {/* Top Warning Bar */}
@@ -44,22 +48,38 @@ export default function MaintenancePage() {
           <div className="bg-white border-4 border-black p-6 shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
             <div className="flex items-center gap-2 border-b-4 border-black pb-2 mb-4">
               <Terminal size={20} />
-              <span className="font-black uppercase">Technical Stats</span>
+              <span className="font-black uppercase">System Logs</span>
             </div>
-            <ul className="space-y-2 text-sm font-bold uppercase">
-              <li className="flex justify-between"><span>Status:</span> <span className="text-[#FFB800]">Repairing</span></li>
-              <li className="flex justify-between"><span>Eta:</span> <span>60-120 MIN</span></li>
-              <li className="flex justify-between"><span>Build:</span> <span>v2.4.0</span></li>
+            <ul className="space-y-3 text-sm font-bold uppercase">
+              <li className="flex justify-between">
+                <span>Status:</span> 
+                <span className="text-[#FFB800]">Maintenance Mode</span>
+              </li>
+              <li className="flex justify-between">
+                <span>Eta:</span> 
+                <span>{config.estimatedDuration || 'TBD'}</span>
+              </li>
+              <li className="flex flex-col gap-2 mt-4 border-t-4 border-black pt-4">
+                 <span className="text-[10px] opacity-50">Transmission from Admin:</span>
+                 <span className="text-sm normal-case leading-tight text-blue-600 bg-blue-50 p-2 border-2 border-dashed border-blue-200">
+                   {config.message}
+                 </span>
+              </li>
             </ul>
           </div>
 
           {/* Action Box */}
           <div className="bg-[#00A2FF] border-4 border-black p-6 shadow-[8px_8px_0_0_rgba(0,0,0,1)] flex flex-col justify-between">
-            <p className="font-black text-white uppercase text-sm mb-4 leading-tight">
-              Need immediate help from the developers?
-            </p>
+            <div>
+              <p className="font-black text-white uppercase text-sm mb-2 leading-tight">
+                Need help?
+              </p>
+              <p className="text-white text-xs font-bold uppercase mb-4 opacity-80">
+                Our support lines are still active during the repair phase.
+              </p>
+            </div>
             <a 
-              href="mailto:support@gitmesh.dev"
+              href={`mailto:${config.contactEmail}`}
               className="w-full bg-white border-4 border-black py-3 text-center font-black uppercase text-black hover:bg-yellow-300 transition-colors shadow-[4px_4px_0_0_rgba(0,0,0,1)] active:shadow-none active:translate-x-1 active:translate-y-1 flex items-center justify-center gap-2"
             >
               Contact Support <ExternalLink size={18} />
@@ -72,10 +92,10 @@ export default function MaintenancePage() {
       <footer className="w-full border-t-4 border-black bg-white p-4 flex flex-col md:flex-row justify-between items-center gap-4 px-10">
         <div className="flex items-center gap-4">
           <div className="w-4 h-4 bg-[#FF3131] border-2 border-black animate-pulse" />
-          <span className="font-black text-sm uppercase">Server Node: 01-B</span>
+          <span className="font-black text-sm uppercase">Secure Node: ACTIVE</span>
         </div>
         <p className="font-black text-xs uppercase opacity-50">
-          Property of GitMesh CE // 2025
+          Property of GitMesh CE // 2026
         </p>
       </footer>
 

--- a/lib/maintenance.ts
+++ b/lib/maintenance.ts
@@ -1,16 +1,118 @@
+import { supabase } from '@/lib/supabase'
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+
 /**
  * Utility functions for managing maintenance mode
  */
 
-export function isMaintenanceMode(): boolean {
-  return process.env.MAINTENANCE_MODE === 'true'
+export interface MaintenanceConfig {
+  enabled: boolean
+  message: string
+  estimatedDuration: string
+  contactEmail: string
 }
 
-export function getMaintenanceConfig() {
-  return {
-    enabled: isMaintenanceMode(),
-    message: process.env.MAINTENANCE_MESSAGE || 'We are currently performing scheduled maintenance.',
-    estimatedDuration: process.env.MAINTENANCE_DURATION || '1-2 hours',
-    contactEmail: process.env.FROM_EMAIL || 'support@gitmesh.dev'
+interface CachedConfig extends MaintenanceConfig {
+  lastUpdated: number
+}
+
+const CACHE_FILE = path.join(os.tmpdir(), 'gitmesh_maintenance_cache.json')
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Checks if the site should redirect to maintenance page.
+ * Uses a file-based cache to avoid hitting the DB on every request.
+ */
+export async function checkMaintenanceRedirection(): Promise<boolean> {
+  try {
+    // 1. Try to read from cache
+    const cacheData = await fs.readFile(CACHE_FILE, 'utf-8').catch(() => null)
+    
+    if (cacheData) {
+      const cached: CachedConfig = JSON.parse(cacheData)
+      const now = Date.now()
+      
+      // If cache is fresh (< 5 mins), use it
+      if (now - cached.lastUpdated < CACHE_TTL) {
+        return cached.enabled
+      }
+    }
+
+    // 2. Cache is missing or stale, fetch fresh data
+    const config = await getMaintenanceConfig()
+    
+    // 3. Update cache
+    await updateMaintenanceCache(config)
+
+    return config.enabled
+
+  } catch (error) {
+    console.error('Error in checkMaintenanceRedirection:', error)
+    // Fail safe: If caching fails, check DB directly to be safe.
+    return isMaintenanceMode()
   }
+}
+
+/**
+ * Manually update the cache.
+ * Useful when admin updates settings to propagate changes immediately (to this instance).
+ */
+export async function updateMaintenanceCache(config: MaintenanceConfig): Promise<void> {
+  try {
+    const newCache: CachedConfig = {
+      ...config,
+      lastUpdated: Date.now()
+    }
+    await fs.writeFile(CACHE_FILE, JSON.stringify(newCache))
+  } catch (error) {
+    console.error('Failed to update maintenance cache:', error)
+  }
+}
+
+/**
+ * Direct check for real-time status (Admin usage)
+ */
+export async function isMaintenanceMode(): Promise<boolean> {
+  const config = await getMaintenanceConfig()
+  return config.enabled
+}
+
+/**
+ * Fetch configuration directly from Supabase (Real-time)
+ */
+export async function getMaintenanceConfig(): Promise<MaintenanceConfig> {
+  const defaults: MaintenanceConfig = {
+    enabled: false,
+    message: 'We are currently performing scheduled maintenance.',
+    estimatedDuration: '1-2 hours',
+    contactEmail: 'support@gitmesh.dev'
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('maintenance_config')
+      .select('*')
+      .eq('id', 1)
+      .single()
+
+    if (error) {
+      console.error('Error fetching maintenance config:', error)
+      return defaults
+    }
+
+    if (data) {
+      return {
+        enabled: data.enabled,
+        message: data.message,
+        estimatedDuration: data.estimated_duration,
+        contactEmail: data.contact_email
+      }
+    }
+  } catch (error) {
+    console.error('Unexpected error checking maintenance mode:', error)
+  }
+
+  return defaults
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,13 +3,15 @@ import { NextResponse } from 'next/server'
 
 export default withAuth(
   function middleware(req) {
-    // For now, disable maintenance mode check to avoid Edge Runtime issues
-    // You can implement this via environment variables or API routes instead
-    const isMaintenancePage = req.nextUrl.pathname === '/maintenance'
-    const isApiRoute = req.nextUrl.pathname.startsWith('/api')
-    const isAdminRoute = req.nextUrl.pathname.startsWith('/admin')
-    
-    // Add any additional middleware logic here
+    // Add current path to headers for Server Components to use
+    const requestHeaders = new Headers(req.headers)
+    requestHeaders.set('x-current-path', req.nextUrl.pathname)
+
+    return NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    })
   },
   {
     callbacks: {

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -55,3 +55,37 @@ CREATE TRIGGER update_content_updated_at
 BEFORE UPDATE ON public.content
 FOR EACH ROW
 EXECUTE FUNCTION update_updated_at_column();
+
+-- 6. Maintenance Configuration
+-- Singleton table to store global maintenance mode settings
+CREATE TABLE IF NOT EXISTS public.maintenance_config (
+  id INT PRIMARY KEY DEFAULT 1 CHECK (id = 1), -- Enforce singleton pattern
+  enabled BOOLEAN DEFAULT FALSE,
+  message TEXT DEFAULT 'We are currently performing scheduled maintenance.',
+  estimated_duration TEXT DEFAULT '1-2 hours',
+  contact_email TEXT DEFAULT 'support@gitmesh.dev',
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Seed the initial configuration if it doesn't exist
+INSERT INTO public.maintenance_config (id, enabled)
+VALUES (1, false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Security Policies
+ALTER TABLE public.maintenance_config ENABLE ROW LEVEL SECURITY;
+
+-- Allow everyone (including unauthenticated users) to read maintenance status
+CREATE POLICY "anon_read_maintenance" ON public.maintenance_config FOR SELECT TO anon USING (true);
+
+-- Allow authenticated users (admins) to manage it
+CREATE POLICY "auth_manage_maintenance" ON public.maintenance_config FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+-- Allow service role full access
+CREATE POLICY "service_manage_maintenance" ON public.maintenance_config FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Trigger to update 'updated_at' automatically
+CREATE TRIGGER update_maintenance_updated_at
+BEFORE UPDATE ON public.maintenance_config
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
This PR migrates the maintenance mode configuration from environment variables (`.env`) to the database (Supabase).
Changes have been tested in local development and deployed instance.

## Key Changes

### 1. Database Schema (`supabase_schema.sql`)
- Added a singleton table `maintenance_config` to store maintenance settings (enabled status, message, duration, contact email).

### 2. Core Logic (`lib/maintenance.ts`)
- Updated logic to fetch configuration from Supabase instead of environment variables.
- **Implemented Caching Strategy**:
  - Uses `os.tmpdir()` to cache the maintenance configuration, to reduce the number of api calls to `Supabase`.

### 3. API & Admin (`app/api/admin/maintenance/route.ts`)
- Updated the API to read/write from the `maintenance_config` table using `upsert`.
- Implemented **Instant Cache Update**: Upon a successful DB update, the API immediately updates the local instance's cache to reflect changes instantly for the administrator.

### 4. Frontend & Build
- Updated `app/maintenance/page.tsx` to display dynamic content from the database (Message, Duration, Email).

### 5. Site-Wide Redirection (`app/layout.tsx` & `middleware.ts`)
- **Middleware**: Injects `x-current-path` header to allow Server Components to know the current URL.
- **Root Layout**: Checks cached maintenance status. If enabled and the user is not an Admin (and not on an allowed route), redirects to `/maintenance`.

## ⚠️ Important Note on Caching & Propagation

To prevent overwhelming the database with requests from every site visitor, the redirection logic uses a file-based cache with a **Time-To-Live (TTL) of 5 minutes**.

- **Immediate Updates**: When an admin updates the settings, the changes are applied immediately to the database and the *current* server instance's cache.
- **Propagation Delay**: In a serverless environment (e.g., Vercel) with multiple running instances (lambdas), other instances may continue to serve cached data for up to **5 minutes** until their cache expires and they fetch fresh data from the database.
- **Configuration**: This duration can be adjusted by modifying `CACHE_TTL` in `@lib/maintenance.ts`.

```typescript
// lib/maintenance.ts
const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
```